### PR TITLE
Adding idiotproof instructions for apt-based linux systems

### DIFF
--- a/guides/source/getting_started.textile
+++ b/guides/source/getting_started.textile
@@ -88,6 +88,8 @@ Usually, run this as the root user:
 
 This will install Jax and a number of other Ruby Gems that it relies upon.
 
+If you encounter an error during install, such as @cannot load such file -- mkmf@, you probably need to install the @ruby-dev@ package.
+
 h4. Creating the Dungeon Application
 
 Now that Jax is installed, we can go ahead and generate the Dungeon application. Start a terminal or command prompt, switch to a directory you have permission to write to, and enter the following command:


### PR DESCRIPTION
Never had to install this package before, so it may be worth a mention.
Trying out JAX one line at a time...

Stumbled upon it by chance. It really should be the top result of [this search](https://www.google.com/search?hl=en&q=tested+webgl+library). (incidentally, this is the search I made before defaulting to three.js, and you can bet I was not the only one)

JAX is a [tested webgl library](http://blog.jaxgl.com/what-is-jax) and should be recognized as such by big G. (see what I did there ?)
