### PR TITLE
Added obvious (or not?) instructions in the testing guide

### DIFF
--- a/guides/source/testing.textile
+++ b/guides/source/testing.textile
@@ -6,14 +6,14 @@ endprologue.
 
 h3. Testing your Application
 
-This should be pretty straightforward, see the "getting started guide":getting_started.html#Write_Some_Tests
+This should be pretty straightforward, see the "getting started guide":getting_started.html#write-some-tests
 
 h3. Testing JAX itself
 
 # Clone "the repository":https://github.com/sinisterchipmunk/jax
 # Run @rake install@
 # Run @rake server@
-# Visit the "jasmine test suite":http://localhost:3000
+# Visit the "local jasmine test suite":http://localhost:3000
 
 Jasmine specs are hosted in @spec/javascripts/@.
 

--- a/guides/source/testing.textile
+++ b/guides/source/testing.textile
@@ -1,5 +1,20 @@
-h2. This Guide Not Yet Started
+h2. Testing
 
 Please come back after I've had time to work on this guide a bit.
 
 endprologue.
+
+h3. Testing your Application
+
+This should be pretty straightforward, see the "getting started guide":getting_started.html#Write_Some_Tests
+
+h3. Testing JAX itself
+
+# Clone "the repository":https://github.com/sinisterchipmunk/jax
+# Run @rake install@
+# Run @rake server@
+# Visit the "jasmine test suite":http://localhost:3000
+
+Jasmine specs are hosted in @spec/javascripts/@.
+
+Happy testing !


### PR DESCRIPTION
I did not find in the suite_controller.rb a way to preview locally the changes made to the textile source files. I found the `generator.rb` and its instructions, but `rake generate_guides` did not run.

On a side note, I'm loving the elegance of it all.
